### PR TITLE
Merge pull request #37 from imagalhaess/dev

### DIFF
--- a/src/main/java/nttdata/personal/julius/api/application/user/CreateUserUseCase.java
+++ b/src/main/java/nttdata/personal/julius/api/application/user/CreateUserUseCase.java
@@ -7,17 +7,22 @@ import nttdata.personal.julius.api.domain.user.Cpf;
 import nttdata.personal.julius.api.domain.user.Email;
 import nttdata.personal.julius.api.domain.user.User;
 import nttdata.personal.julius.api.domain.user.UserRepository;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 public class CreateUserUseCase {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    public CreateUserUseCase(UserRepository userRepository) {
+    public CreateUserUseCase(UserRepository userRepository,  PasswordEncoder passwordEncoder) {
         this.userRepository = userRepository;
+        this.passwordEncoder = new BCryptPasswordEncoder();
     }
 
     public UserResponse execute(UserRequest request) {
         Email email = new Email(request.email());
         Cpf cpf = new Cpf(request.cpf());
+        String encryptedPassword = passwordEncoder.encode(request.password());
 
         if (userRepository.findByCpf(cpf).isPresent()) {
             throw new BusinessException("CPF já cadastrado no sistema.");
@@ -26,9 +31,9 @@ public class CreateUserUseCase {
             throw new BusinessException("Email já cadastrado no sistema.");
         }
 
-        User user = new User(request.name(), email, cpf, request.password());
+        User user = new User(request.name(), email, cpf, encryptedPassword);
         userRepository.save(user);
 
-        return UserResponse.fromDomain(user); // Retorna o DTO de resposta
+        return UserResponse.fromDomain(user);
     }
 }

--- a/src/main/java/nttdata/personal/julius/api/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/nttdata/personal/julius/api/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package nttdata.personal.julius.api.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(
+                        session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // Sem estado (JWT)
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
+                        .anyRequest().authenticated() // Todo o resto exige estar logado
+                )
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/nttdata/personal/julius/api/infrastructure/config/UseCaseConfig.java
+++ b/src/main/java/nttdata/personal/julius/api/infrastructure/config/UseCaseConfig.java
@@ -10,13 +10,14 @@ import nttdata.personal.julius.api.domain.user.UserRepository;
 import nttdata.personal.julius.api.infrastructure.messaging.kafka.producer.TransactionEventProducer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 public class UseCaseConfig {
 
     @Bean
-    public CreateUserUseCase createUserUseCase(UserRepository userRepository) {
-        return new CreateUserUseCase(userRepository);
+    public CreateUserUseCase createUserUseCase(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        return new CreateUserUseCase(userRepository, passwordEncoder);
     }
 
     @Bean


### PR DESCRIPTION
fix: remove pastas desnecessárias

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces basic security and secure password storage.
> 
> - **Security**: New `SecurityConfig` sets stateless sessions, disables CSRF, permits `"/api/auth/**"` and `POST "/api/users"`, and requires authentication for all other requests. Provides a `PasswordEncoder` bean (`BCryptPasswordEncoder`).
> - **User creation**: `CreateUserUseCase` now encodes `password` using `PasswordEncoder` and persists the hashed value instead of plaintext.
> - **Wiring**: `UseCaseConfig` injects `PasswordEncoder` into `CreateUserUseCase`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2a714f709db71bbbe2b8a125795836f750429e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->